### PR TITLE
Adds a unique error message for HTTP 429s to RPC subprovider

### DIFF
--- a/subproviders/rpc.js
+++ b/subproviders/rpc.js
@@ -45,6 +45,11 @@ RpcSource.prototype.handleRequest = function(payload, next, end){
           const err = new Error(msg)
           return end(new JsonRpcError.InternalError(err))
         })()
+      case 429: // Too many requests (rate limiting)
+        return (function(){
+          const err = new Error(`Too Many Requests`)
+          return end(new JsonRpcError.InternalError(err))
+        })()
       default:
         if (res.statusCode != 200) {
           return end(new JsonRpcError.InternalError(res.body))


### PR DESCRIPTION
I've been creating a subprovider to track some useful metrics and found being able to track 429s useful.  Let me know if you have any feedback.