### PR TITLE
Adds useSkipCache option to ProviderEngine constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,13 +21,15 @@ function Web3ProviderEngine(opts) {
   // parse options
   opts = opts || {}
 
+  self.useSkipCache = typeof opts.useSkipCache !== 'undefined' ? opts.useSkipCache : true
+
   // block polling
   const directProvider = { sendAsync: self._handleAsync.bind(self) }
   const blockTrackerProvider = opts.blockTrackerProvider || directProvider
   self._blockTracker = opts.blockTracker || new EthBlockTracker({
     provider: blockTrackerProvider,
     pollingInterval: opts.pollingInterval || 4000,
-    setSkipCacheFlag: true,
+    setSkipCacheFlag: this.useSkipCache,
   })
 
   // set initialization blocker
@@ -127,7 +129,7 @@ Web3ProviderEngine.prototype.sendAsync = function(payload, cb){
 // private
 
 Web3ProviderEngine.prototype._getBlockByNumber = function(blockNumber, cb) {
-  const req = createPayload({ method: 'eth_getBlockByNumber', params: [blockNumber, false], skipCache: true })
+  const req = createPayload({ method: 'eth_getBlockByNumber', params: [blockNumber, false], skipCache: this.useSkipCache })
   this._handleAsync(req, (err, res) => {
     if (err) return cb(err)
     return cb(null, res.result)

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function Web3ProviderEngine(opts) {
   self._blockTracker = opts.blockTracker || new EthBlockTracker({
     provider: blockTrackerProvider,
     pollingInterval: opts.pollingInterval || 4000,
-    setSkipCacheFlag: this.useSkipCache,
+    setSkipCacheFlag: self.useSkipCache,
   })
 
   // set initialization blocker

--- a/index.js
+++ b/index.js
@@ -129,7 +129,11 @@ Web3ProviderEngine.prototype.sendAsync = function(payload, cb){
 // private
 
 Web3ProviderEngine.prototype._getBlockByNumber = function(blockNumber, cb) {
-  const req = createPayload({ method: 'eth_getBlockByNumber', params: [blockNumber, false], skipCache: this.useSkipCache })
+  const payload = { method: 'eth_getBlockByNumber', params: [blockNumber, false] }
+  if (this.useSkipCache) {
+    payload.skipCache = this.useSkipCache
+  }
+  const req = createPayload(payload)
   this._handleAsync(req, (err, res) => {
     if (err) return cb(err)
     return cb(null, res.result)


### PR DESCRIPTION
Adds a option that would allow users to disable the use of the `skipCache` parameter for `eth_getBlockByNumber` requests.  This parameter is rejected by Parity and some JSON-RPC service providers like Alchemy.

    // Example usage to disable the parameter
    const engine = new ProviderEngine({ useSkipCache: false })

Let me know if you have any feedback.  The default behavior should stay the same with this PR.

Ref: #311