### PR TITLE
add _getBlockByNumberWithRetry to be less fragile against load balancers like infura

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function Web3ProviderEngine(opts) {
 
   // set initialization blocker
   self._ready = new Stoplight()
-  
+
   // local state
   self.currentBlock = null
   self._providers = []
@@ -49,12 +49,13 @@ Web3ProviderEngine.prototype.start = function(cb = noop){
   // on new block, request block body and emit as events
   self._blockTracker.on('latest', (blockNumber) => {
     // get block body
-    self._getBlockByNumber(blockNumber, (err, block) => {
+    self._getBlockByNumberWithRetry(blockNumber, (err, block) => {
       if (err) {
         this.emit('error', err)
         return
       }
       if (!block) {
+        console.log(block)
         this.emit('error', new Error("Could not find block"))
         return
       }
@@ -130,6 +131,43 @@ Web3ProviderEngine.prototype.sendAsync = function(payload, cb){
 
 // private
 
+Web3ProviderEngine.prototype._getBlockByNumberWithRetry = function(blockNumber, cb) {
+  const self = this
+
+  let retriesRemaining = 5
+
+  attemptRequest()
+  return
+
+  function attemptRequest () {
+    self._getBlockByNumber(blockNumber, afterRequest)
+  }
+
+  function afterRequest (err, block) {
+    // anomalous error occurred
+    if (err) return cb(err)
+    // block not ready yet
+    if (!block) {
+      if (retriesRemaining > 0) {
+        // wait 1s then try again
+        retriesRemaining--
+        setTimeout(function () {
+          attemptRequest()
+        }, 1000)
+        return
+      } else {
+        // give up, return a null block
+        cb(null, null)
+        return
+      }
+    }
+    // otherwise return result
+    cb(null, block)
+    return
+  }
+}
+
+
 Web3ProviderEngine.prototype._getBlockByNumber = function(blockNumber, cb) {
   const req = createPayload({ method: 'eth_getBlockByNumber', params: [blockNumber, false], skipCache: true })
   this._handleAsync(req, (err, res) => {
@@ -147,7 +185,7 @@ Web3ProviderEngine.prototype._handleAsync = function(payload, finished) {
   var stack = []
 
   next()
-  
+
   function next(after) {
     currentProvider += 1
     stack.unshift(after)


### PR DESCRIPTION
Fixes #313

also related https://github.com/MetaMask/web3-provider-engine/pull/314

we now retry up to 5 times internally after failing to get a block body