### PR TITLE
Configure eth-block-tracker to not keep event loop active

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ function Web3ProviderEngine(opts) {
     provider: blockTrackerProvider,
     pollingInterval: opts.pollingInterval || 4000,
     setSkipCacheFlag: true,
+    keepEventLoopActive: false,
   })
 
   // set initialization blocker


### PR DESCRIPTION
This library is using eth-block-tracker in a way that causes Node.js's event loop to never exit. This forces tools in the ecosystem, such as the OpenZeppelin CLI, to have to insert `process.exit` calls to force the process to exit which is really bad practice (https://github.com/OpenZeppelin/openzeppelin-sdk/issues/1483).

This enables an option in eth-block-tracker that will fix the issue.