### PR TITLE
Update `ethereumjs-tx` to `@ethereumjs/tx` to support EIP1559 transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "ganache-core/**/elliptic": "^6.5.2"
   },
   "dependencies": {
-    "@ethereumjs/common": "^2.4.0",
     "@ethereumjs/tx": "^3.3.0",
     "async": "^2.5.0",
     "backoff": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "eth-rpc-errors": "^3.0.0",
     "eth-sig-util": "^1.4.2",
     "ethereumjs-block": "^1.2.2",
-    "ethereumjs-tx": "^1.2.0",
     "ethereumjs-util": "^5.1.5",
     "ethereumjs-vm": "^2.3.4",
     "json-stable-stringify": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "ganache-core/**/elliptic": "^6.5.2"
   },
   "dependencies": {
+    "@ethereumjs/common": "^2.4.0",
+    "@ethereumjs/tx": "^3.3.0",
     "async": "^2.5.0",
     "backoff": "^2.5.0",
     "clone": "^2.0.0",

--- a/subproviders/hooked-wallet-ethtx.js
+++ b/subproviders/hooked-wallet-ethtx.js
@@ -10,7 +10,7 @@
 
 const inherits = require('util').inherits
 const HookedWalletProvider = require('./hooked-wallet.js')
-const { Transaction } = require('@ethereumjs/tx')
+const { TransactionFactory } = require('@ethereumjs/tx')
 const ethUtil = require('ethereumjs-util')
 const sigUtil = require('eth-sig-util')
 
@@ -32,7 +32,7 @@ function HookedWalletEthTxSubprovider(opts) {
     opts.getPrivateKey(txData.from, function(err, privateKey) {
       if (err) return cb(err)
 
-      var tx = new Transaction(txData)
+      var tx = TransactionFactory.fromTxData(txData)
       tx.sign(privateKey)
       cb(null, '0x' + tx.serialize().toString('hex'))
     })

--- a/subproviders/hooked-wallet-ethtx.js
+++ b/subproviders/hooked-wallet-ethtx.js
@@ -1,5 +1,5 @@
 /*
- * Uses ethereumjs-tx to sign a transaction.
+ * Uses @ethereumjs/tx to sign a transaction.
  *
  * The two callbacks a user needs to implement are:
  * - getAccounts() -- array of addresses supported
@@ -10,7 +10,7 @@
 
 const inherits = require('util').inherits
 const HookedWalletProvider = require('./hooked-wallet.js')
-const EthTx = require('ethereumjs-tx')
+const { Transaction } = require('@ethereumjs/tx')
 const ethUtil = require('ethereumjs-util')
 const sigUtil = require('eth-sig-util')
 
@@ -32,7 +32,7 @@ function HookedWalletEthTxSubprovider(opts) {
     opts.getPrivateKey(txData.from, function(err, privateKey) {
       if (err) return cb(err)
 
-      var tx = new EthTx(txData)
+      var tx = new Transaction(txData)
       tx.sign(privateKey)
       cb(null, '0x' + tx.serialize().toString('hex'))
     })

--- a/subproviders/nonce-tracker.js
+++ b/subproviders/nonce-tracker.js
@@ -1,8 +1,8 @@
 const inherits = require('util').inherits
+const { TransactionFactory } = require('@ethereumjs/tx')
 const ethUtil = require('ethereumjs-util')
 const Subprovider = require('./subprovider.js')
 const blockTagForPayload = require('../util/rpc-cache-utils').blockTagForPayload
-const { TransactionFactory } = require('@ethereumjs/tx')
 
 module.exports = NonceTrackerSubprovider
 

--- a/subproviders/nonce-tracker.js
+++ b/subproviders/nonce-tracker.js
@@ -1,8 +1,9 @@
 const inherits = require('util').inherits
-const Transaction = require('ethereumjs-tx')
 const ethUtil = require('ethereumjs-util')
 const Subprovider = require('./subprovider.js')
 const blockTagForPayload = require('../util/rpc-cache-utils').blockTagForPayload
+const Common = require('@ethereumjs/common')
+const { TransactionFactory } = require('@ethereumjs/tx')
 
 module.exports = NonceTrackerSubprovider
 
@@ -57,9 +58,11 @@ NonceTrackerSubprovider.prototype.handleRequest = function(payload, next, end){
         if (err) return cb()
         // parse raw tx
         var rawTx = payload.params[0]
-        var stripped = ethUtil.stripHexPrefix(rawTx)
         var rawData = Buffer.from(ethUtil.stripHexPrefix(rawTx), 'hex')
-        var tx = new Transaction(Buffer.from(ethUtil.stripHexPrefix(rawTx), 'hex'))
+        console.log({ rawData });
+        // var tx = new Transaction(Buffer.from(ethUtil.stripHexPrefix(rawTx), 'hex'))
+        const common = new Common({ chain: 'ropsten', hardfork: 'london', eips:[1559] })
+        const tx = TransactionFactory.fromSerializedData(rawData, { common })
         // extract address
         var address = '0x'+tx.getSenderAddress().toString('hex').toLowerCase()
         // extract nonce and increment

--- a/subproviders/nonce-tracker.js
+++ b/subproviders/nonce-tracker.js
@@ -2,7 +2,6 @@ const inherits = require('util').inherits
 const ethUtil = require('ethereumjs-util')
 const Subprovider = require('./subprovider.js')
 const blockTagForPayload = require('../util/rpc-cache-utils').blockTagForPayload
-const Common = require('@ethereumjs/common')
 const { TransactionFactory } = require('@ethereumjs/tx')
 
 module.exports = NonceTrackerSubprovider
@@ -16,7 +15,7 @@ module.exports = NonceTrackerSubprovider
 
 inherits(NonceTrackerSubprovider, Subprovider)
 
-function NonceTrackerSubprovider(opts){
+function NonceTrackerSubprovider(){
   const self = this
 
   self.nonceCache = {}
@@ -59,10 +58,7 @@ NonceTrackerSubprovider.prototype.handleRequest = function(payload, next, end){
         // parse raw tx
         var rawTx = payload.params[0]
         var rawData = Buffer.from(ethUtil.stripHexPrefix(rawTx), 'hex')
-        console.log({ rawData });
-        // var tx = new Transaction(Buffer.from(ethUtil.stripHexPrefix(rawTx), 'hex'))
-        const common = new Common({ chain: 'ropsten', hardfork: 'london', eips:[1559] })
-        const tx = TransactionFactory.fromSerializedData(rawData, { common })
+        const tx = TransactionFactory.fromSerializedData(rawData)
         // extract address
         var address = '0x'+tx.getSenderAddress().toString('hex').toLowerCase()
         // extract nonce and increment

--- a/subproviders/vm.js
+++ b/subproviders/vm.js
@@ -3,7 +3,7 @@ const inherits = require('util').inherits
 const Stoplight = require('../util/stoplight.js')
 const createVm = require('ethereumjs-vm/dist/hooked').fromWeb3Provider
 const Block = require('ethereumjs-block')
-const { Transaction } = require('@ethereumjs/tx')
+const { TransactionFactory } = require('@ethereumjs/tx')
 const ethUtil = require('ethereumjs-util')
 const rpcHexEncoding = require('../util/rpc-hex-encoding.js')
 const Subprovider = require('./subprovider.js')
@@ -142,7 +142,7 @@ VmSubprovider.prototype.runVm = function(payload, cb){
     gasPrice: txParams.gasPrice ? ethUtil.addHexPrefix(txParams.gasPrice) : undefined,
     nonce: txParams.nonce ? ethUtil.addHexPrefix(txParams.nonce) : undefined,
   }
-  const tx = new Transaction(normalizedTxParams)
+  const tx = TransactionFactory.fromTxData(normalizedTxParams)
   const fakeTx = Object.create(tx)
   // override getSenderAddress
   fakeTx.getSenderAddress = () => normalizedTxParams.from

--- a/subproviders/vm.js
+++ b/subproviders/vm.js
@@ -3,9 +3,8 @@ const inherits = require('util').inherits
 const Stoplight = require('../util/stoplight.js')
 const createVm = require('ethereumjs-vm/dist/hooked').fromWeb3Provider
 const Block = require('ethereumjs-block')
-const FakeTransaction = require('ethereumjs-tx/fake.js')
+const { Transaction } = require('@ethereumjs/tx')
 const ethUtil = require('ethereumjs-util')
-const createPayload = require('../util/create-payload.js')
 const rpcHexEncoding = require('../util/rpc-hex-encoding.js')
 const Subprovider = require('./subprovider.js')
 
@@ -143,8 +142,11 @@ VmSubprovider.prototype.runVm = function(payload, cb){
     gasPrice: txParams.gasPrice ? ethUtil.addHexPrefix(txParams.gasPrice) : undefined,
     nonce: txParams.nonce ? ethUtil.addHexPrefix(txParams.nonce) : undefined,
   }
-  var tx = new FakeTransaction(normalizedTxParams)
-  tx._from = normalizedTxParams.from || '0x0000000000000000000000000000000000000000'
+  const tx = new Transaction(normalizedTxParams)
+  const fakeTx = Object.create(tx)
+  const { from } = normalizedTxParams
+  // override getSenderAddress
+  fakeTx.getSenderAddress = () => { return from }
 
   vm.runTx({
     tx: tx,

--- a/subproviders/vm.js
+++ b/subproviders/vm.js
@@ -144,9 +144,8 @@ VmSubprovider.prototype.runVm = function(payload, cb){
   }
   const tx = new Transaction(normalizedTxParams)
   const fakeTx = Object.create(tx)
-  const { from } = normalizedTxParams
   // override getSenderAddress
-  fakeTx.getSenderAddress = () => { return from }
+  fakeTx.getSenderAddress = () => normalizedTxParams.from
 
   vm.runTx({
     tx: tx,

--- a/subproviders/vm.js
+++ b/subproviders/vm.js
@@ -148,7 +148,7 @@ VmSubprovider.prototype.runVm = function(payload, cb){
   fakeTx.getSenderAddress = () => normalizedTxParams.from
 
   vm.runTx({
-    tx: tx,
+    tx: fakeTx,
     block: block,
     skipNonce: true,
     skipBalance: true

--- a/test/nonce.js
+++ b/test/nonce.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const Transaction = require('ethereumjs-tx')
+const { Transaction } = require('@ethereumjs/tx')
 const ethUtil = require('ethereumjs-util')
 const ProviderEngine = require('../index.js')
 const FixtureProvider = require('../subproviders/fixture.js')
@@ -8,7 +8,6 @@ const HookedWalletProvider = require('../subproviders/hooked-wallet.js')
 const TestBlockProvider = require('./util/block.js')
 const createPayload = require('../util/create-payload.js')
 const injectMetrics = require('./util/inject-metrics')
-
 
 test('basic nonce tracking', function(t){
   t.plan(11)

--- a/test/nonce.js
+++ b/test/nonce.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const { Transaction } = require('@ethereumjs/tx')
+const { TransactionFactory } = require('@ethereumjs/tx')
 const ethUtil = require('ethereumjs-util')
 const ProviderEngine = require('../index.js')
 const FixtureProvider = require('../subproviders/fixture.js')
@@ -19,7 +19,7 @@ test('basic nonce tracking', function(t){
   // sign all tx's
   var providerA = injectMetrics(new HookedWalletProvider({
     signTransaction: function(txParams, cb){
-      var tx = new Transaction(txParams)
+      var tx = TransactionFactory.fromTxData(txParams)
       tx.sign(privateKey)
       var rawTx = '0x'+tx.serialize().toString('hex')
       cb(null, rawTx)
@@ -34,7 +34,7 @@ test('basic nonce tracking', function(t){
     eth_getTransactionCount: '0x00',
     eth_sendRawTransaction: function(payload, next, done){
       var rawTx = ethUtil.toBuffer(payload.params[0])
-      var tx = new Transaction(rawTx)
+      var tx = new TransactionFactory.fromTxData(rawTx)
       var hash = '0x'+tx.hash().toString('hex')
       done(null, hash)
     },
@@ -102,7 +102,7 @@ test('nonce tracking - on error', function(t){
   // sign all tx's
   var providerA = injectMetrics(new HookedWalletProvider({
     signTransaction: function(txParams, cb){
-      var tx = new Transaction(txParams)
+      var tx = TransactionFactory.fromTxData(txParams)
       tx.sign(privateKey)
       var rawTx = '0x'+tx.serialize().toString('hex')
       cb(null, rawTx)

--- a/test/wallet.js
+++ b/test/wallet.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const Transaction = require('ethereumjs-tx')
+const { Transaction } = require('@ethereumjs/tx')
 const ethUtil = require('ethereumjs-util')
 const ProviderEngine = require('../index.js')
 const FixtureProvider = require('../subproviders/fixture.js')
@@ -24,9 +24,9 @@ test('tx sig', function(t){
       cb(null, [addressHex])
     },
     signTransaction: function(txParams, cb){
-      var tx = new Transaction(txParams)
-      tx.sign(privateKey)
-      var rawTx = '0x'+tx.serialize().toString('hex')
+      const tx = new Transaction(txParams)
+      const signedTransaction = tx.sign(privateKey)
+      var rawTx = '0x'+signedTransaction.serialize().toString('hex')
       cb(null, rawTx)
     },
   }))

--- a/test/wallet.js
+++ b/test/wallet.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const { Transaction } = require('@ethereumjs/tx')
+const { TransactionFactory } = require('@ethereumjs/tx')
 const ethUtil = require('ethereumjs-util')
 const ProviderEngine = require('../index.js')
 const FixtureProvider = require('../subproviders/fixture.js')
@@ -24,7 +24,7 @@ test('tx sig', function(t){
       cb(null, [addressHex])
     },
     signTransaction: function(txParams, cb){
-      const tx = new Transaction(txParams)
+      const tx = TransactionFactory.fromTxData(txParams)
       const signedTransaction = tx.sign(privateKey)
       var rawTx = '0x'+signedTransaction.serialize().toString('hex')
       cb(null, rawTx)
@@ -39,7 +39,7 @@ test('tx sig', function(t){
     eth_getTransactionCount: '0x00',
     eth_sendRawTransaction: function(payload, next, done){
       var rawTx = ethUtil.toBuffer(payload.params[0])
-      var tx = new Transaction(rawTx)
+      var tx = TransactionFactory.fromSerializedData(rawTx)
       var hash = '0x'+tx.hash().toString('hex')
       done(null, hash)
     },
@@ -113,7 +113,7 @@ test('no such account', function(t){
     eth_getTransactionCount: '0x00',
     eth_sendRawTransaction: function(payload, next, done){
       var rawTx = ethUtil.toBuffer(payload.params[0])
-      var tx = new Transaction(rawTx)
+      var tx = TransactionFactory.fromTxData(rawTx)
       var hash = '0x'+tx.hash().toString('hex')
       done(null, hash)
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,6 +769,22 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@ethereumjs/common@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.4.0.tgz#2d67f6e6ba22246c5c89104e6b9a119fb3039766"
+  integrity sha512-UdkhFWzWcJCZVsj1O/H8/oqj/0RVYjLc1OhPjBrQdALAkQHpCp8xXI4WLnuGTADqTdJZww0NtgwG+TRPkXt27w==
+  dependencies:
+    crc-32 "^1.2.0"
+    ethereumjs-util "^7.1.0"
+
+"@ethereumjs/tx@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.3.0.tgz#14ed1b7fa0f28e1cd61e3ecbdab824205f6a4378"
+  integrity sha512-yTwEj2lVzSMgE6Hjw9Oa1DZks/nKTWM8Wn4ykDNapBPua2f4nXO3qKnni86O6lgDj5fVNRqbDsD0yy7/XNGDEA==
+  dependencies:
+    "@ethereumjs/common" "^2.4.0"
+    ethereumjs-util "^7.1.0"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -795,6 +811,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/bn.js@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
+  integrity sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -814,6 +837,20 @@
   version "12.12.35"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.35.tgz#1e61b226c14380f4384f70cfe49a65c2c553ad2b"
   integrity sha512-ASYsaKecA7TUsDrqIGPNk3JeEox0z/0XR/WsJJ8BIX/9+SkMSImQXKWfU/yBrSyc7ZSE/NPqLu36Nur0miCFfQ==
+
+"@types/pbkdf2@^3.0.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/pbkdf2/-/pbkdf2-3.1.0.tgz#039a0e9b67da0cdc4ee5dab865caa6b267bb66b1"
+  integrity sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/secp256k1@^4.0.1":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/secp256k1/-/secp256k1-4.0.3.tgz#1b8e55d8e00f08ee7220b4d59a6abe89c37a901c"
+  integrity sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==
+  dependencies:
+    "@types/node" "*"
 
 "@web3-js/scrypt-shim@^0.1.0":
   version "0.1.0"
@@ -1838,6 +1875,11 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
+blakejs@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.1.tgz#bf313053978b2cd4c444a48795710be05c785702"
+  integrity sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg==
+
 bluebird@^3.5.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -1857,6 +1899,11 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.10.0, bn.js@^4.11.0, bn.js@^4
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
+
+bn.js@^5.1.2:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
+  integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
 body-parser@1.19.0, body-parser@^1.16.0:
   version "1.19.0"
@@ -1922,7 +1969,7 @@ browser-resolve@^1.11.0, browser-resolve@^1.7.0:
   dependencies:
     resolve "1.1.7"
 
-browserify-aes@^1.0.0, browserify-aes@^1.0.4, browserify-aes@^1.0.6:
+browserify-aes@^1.0.0, browserify-aes@^1.0.4, browserify-aes@^1.0.6, browserify-aes@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
   integrity sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
@@ -2575,6 +2622,14 @@ cors@^2.8.1:
     object-assign "^4"
     vary "^1"
 
+crc-32@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208"
+  integrity sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==
+  dependencies:
+    exit-on-epipe "~1.0.1"
+    printj "~1.1.0"
+
 create-ecdh@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
@@ -2594,7 +2649,7 @@ create-hash@^1.1.0, create-hash@^1.1.1, create-hash@^1.1.2, create-hash@^1.2.0:
     ripemd160 "^2.0.1"
     sha.js "^2.4.0"
 
-create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
+create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4, create-hmac@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
   integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
@@ -3430,6 +3485,27 @@ ethereum-common@^0.0.18:
   resolved "https://registry.yarnpkg.com/ethereum-common/-/ethereum-common-0.0.18.tgz#2fdc3576f232903358976eb39da783213ff9523f"
   integrity sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=
 
+ethereum-cryptography@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz#8d6143cfc3d74bf79bbd8edecdf29e4ae20dd191"
+  integrity sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==
+  dependencies:
+    "@types/pbkdf2" "^3.0.0"
+    "@types/secp256k1" "^4.0.1"
+    blakejs "^1.1.0"
+    browserify-aes "^1.2.0"
+    bs58check "^2.1.2"
+    create-hash "^1.2.0"
+    create-hmac "^1.1.7"
+    hash.js "^1.1.7"
+    keccak "^3.0.0"
+    pbkdf2 "^3.0.17"
+    randombytes "^2.1.0"
+    safe-buffer "^5.1.2"
+    scrypt-js "^3.0.0"
+    secp256k1 "^4.0.1"
+    setimmediate "^1.0.5"
+
 ethereumjs-abi@0.6.5:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz#5a637ef16ab43473fa72a29ad90871405b3f5241"
@@ -3566,6 +3642,18 @@ ethereumjs-util@^5.0.0, ethereumjs-util@^5.0.1, ethereumjs-util@^5.1.1, ethereum
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
     secp256k1 "^3.0.1"
+
+ethereumjs-util@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz#e2b43a30bfcdbcb432a4eb42bd5f2393209b3fd5"
+  integrity sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.1.2"
+    create-hash "^1.1.2"
+    ethereum-cryptography "^0.1.3"
+    ethjs-util "0.1.6"
+    rlp "^2.2.4"
 
 ethereumjs-util@~6.1.0:
   version "6.1.0"
@@ -3784,6 +3872,11 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
+
+exit-on-epipe@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
+  integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
 
 expand-brackets@^2.1.4:
   version "2.1.4"
@@ -4587,7 +4680,7 @@ hash.js@1.1.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
 
-hash.js@^1.0.0, hash.js@^1.0.3:
+hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
@@ -5312,6 +5405,14 @@ keccak@^2.0.0:
     nan "^2.14.0"
     safe-buffer "^5.2.0"
 
+keccak@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.1.tgz#ae30a0e94dbe43414f741375cff6d64c8bea0bff"
+  integrity sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==
+  dependencies:
+    node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.0"
+
 keccakjs@^0.2.0:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/keccakjs/-/keccakjs-0.2.3.tgz#5e4e969ce39689a3861f445d7752ee3477f9fe72"
@@ -5980,6 +6081,11 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-addon-api@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
+  integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
+
 node-fetch@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
@@ -5997,6 +6103,11 @@ node-fetch@~1.7.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-gyp-build@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
+  integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
 
 node-releases@^1.1.53:
   version "1.1.53"
@@ -6400,6 +6511,17 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+pbkdf2@^3.0.17:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
+  integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
+  dependencies:
+    create-hash "^1.1.2"
+    create-hmac "^1.1.4"
+    ripemd160 "^2.0.1"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
+
 pbkdf2@^3.0.3, pbkdf2@^3.0.9:
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
@@ -6484,6 +6606,11 @@ pretty-hrtime@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
+
+printj@~1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
+  integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"
@@ -7074,6 +7201,13 @@ rlp@^2.0.0, rlp@^2.2.1, rlp@^2.2.2, rlp@^2.2.3:
   dependencies:
     bn.js "^4.11.1"
 
+rlp@^2.2.4:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/rlp/-/rlp-2.2.6.tgz#c80ba6266ac7a483ef1e69e8e2f056656de2fb2c"
+  integrity sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==
+  dependencies:
+    bn.js "^4.11.1"
+
 run-async@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.0.tgz#e59054a5b86876cfae07f431d18cbaddc594f1e8"
@@ -7127,6 +7261,11 @@ scrypt-js@2.0.3:
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.3.tgz#bb0040be03043da9a012a2cea9fc9f852cfc87d4"
   integrity sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=
 
+scrypt-js@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
+  integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
+
 scrypt.js@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/scrypt.js/-/scrypt.js-0.3.0.tgz#6c62d61728ad533c8c376a2e5e3e86d41a95c4c0"
@@ -7168,6 +7307,15 @@ secp256k1@^3.0.1:
     elliptic "^6.5.2"
     nan "^2.14.0"
     safe-buffer "^5.1.2"
+
+secp256k1@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.2.tgz#15dd57d0f0b9fdb54ac1fa1694f40e5e9a54f4a1"
+  integrity sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==
+  dependencies:
+    elliptic "^6.5.2"
+    node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.0"
 
 seedrandom@3.0.1:
   version "3.0.1"


### PR DESCRIPTION
We need this in the mobile app to interoperate with type two (eip1559) transactions without crashing the app

The fake transaction re-implementation is 1:1 from https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/tx#fake-transaction

re: https://github.com/MetaMask/metamask-mobile/issues/2851