### PR TITLE
chore: replace json-stable-stringify with safe-stable-stringify

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ethereumjs-block": "^1.2.2",
     "ethereumjs-util": "^5.1.5",
     "ethereumjs-vm": "^2.3.4",
-    "json-stable-stringify": "^1.0.1",
+    "safe-stable-stringify": "^2.2.0",
     "promise-to-callback": "^1.0.0",
     "readable-stream": "^2.2.9",
     "request": "^2.85.0",

--- a/util/rpc-cache-utils.js
+++ b/util/rpc-cache-utils.js
@@ -1,4 +1,4 @@
-const stringify = require('json-stable-stringify')
+const stringify = require('safe-stable-stringify')
 
 module.exports = {
   cacheIdentifierForPayload: cacheIdentifierForPayload,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7251,6 +7251,11 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
+safe-stable-stringify@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.2.0.tgz#26a52f13a6988de16a0d88e20248f38e8a7d840c"
+  integrity sha512-C6AuMdYPuPV/P1leplHNu0lgc2LAElq/g3TdoksDCIVtBhr78o/CH03bt/9SKqugFbKU9CUjsNlCu0fjtQzQUw==
+
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"


### PR DESCRIPTION
This is a performance improvement as the latter is actually faster.

json-stable-stringify x 13,870 ops/sec ±0.72% (94 runs sampled)
safe-stable-stringify x 30,367 ops/sec ±0.39% (96 runs sampled)

The only difference is that objects with circular reference are from
now on also accepted instead of throwing an error.