### PR TITLE
Etherscan upgrades

### DIFF
--- a/subproviders/etherscan.js
+++ b/subproviders/etherscan.js
@@ -25,6 +25,7 @@
 const xhr = process.browser ? require('xhr') : require('request')
 const inherits = require('util').inherits
 const Subprovider = require('./subprovider.js')
+const MAINNET = 'mainnet'
 
 module.exports = EtherscanProvider
 
@@ -32,7 +33,7 @@ inherits(EtherscanProvider, Subprovider)
 
 function EtherscanProvider(opts) {
   opts = opts || {}
-  this.network = opts.network || 'api'
+  this.network = opts.network || MAINNET
   this.apiKey = opts.apiKey || ''
   this.proto = (opts.https || false) ? 'https' : 'http'
   this.requests = [];
@@ -189,8 +190,9 @@ function toQueryString(params) {
 }
 
 function etherscanXHR(apiKey, useGetMethod, proto, network, module, action, params, end) {
+  const subdomain = network === MAINNET ? 'api' : `api-${network}`
   const qs = toQueryString({ module: module, action: action, apikey: apiKey }) + '&' + toQueryString(params)
-  const uri = `${proto}://${network}.etherscan.io/api?${qs}`
+  const uri = `${proto}://${subdomain}.etherscan.io/api?${qs}`
   xhr({
     uri: uri,
     method: useGetMethod ? 'GET' : 'POST',

--- a/subproviders/etherscan.js
+++ b/subproviders/etherscan.js
@@ -232,7 +232,7 @@ function etherscanXHR(apiKey, useGetMethod, proto, network, module, action, para
     // NOTE: or use id === -1? (id=1 is 'success')
     if ((module === 'proxy') && data.error) {
       // Maybe send back the code too?
-      return end(data.error.message)
+      return end(data.error.message || data.error)
     }
 
     // NOTE: or data.status !== 1?

--- a/subproviders/etherscan.js
+++ b/subproviders/etherscan.js
@@ -124,7 +124,10 @@ function handlePayload(apiKey, proto, network, payload, next, end){
 
         const params = {}
         for (let i = 0, l = Math.min(payload.params.length, props.length); i < l; i++) {
-          params[props[i]] = payload.params[i]
+          const value = payload.params[i]
+          if (value !== undefined) {
+            params[props[i]] = value
+          }
         }
 
         etherscanXHR(apiKey, true, proto, network, 'account', 'txlist', params, end)

--- a/subproviders/etherscan.js
+++ b/subproviders/etherscan.js
@@ -66,6 +66,7 @@ EtherscanProvider.prototype._handleRequests = function(self){
 }
 
 EtherscanProvider.prototype.handleRequest = function(payload, next, end){
+  end = normalizeCallback(end)
   var requestObject = {proto: this.proto, network: this.network, payload: payload, next: next, end: end},
     self = this;
 
@@ -264,3 +265,16 @@ function ref (timeout) {
   if (timeout.ref) timeout.ref();
 }
 
+function normalizeError (err) {
+  if (err instanceof Error) return err
+
+  return new Error("" + err)
+}
+
+function normalizeCallback (cb) {
+  return function (err, result) {
+    if (err) err = normalizeError(err)
+
+    cb(err, result)
+  }
+}

--- a/subproviders/etherscan.js
+++ b/subproviders/etherscan.js
@@ -41,10 +41,18 @@ function EtherscanProvider(opts) {
   this.interval = isNaN(opts.interval) ? 1000 : opts.interval;
   this.retryFailed = typeof opts.retryFailed === 'boolean' ? opts.retryFailed : true; // not built yet
 
-  setInterval(this.handleRequests, this.interval, this);
+  this.intervalId = setInterval(this.handleRequests, this.interval, this);
+  unref(this.intervalId);
 }
 
 EtherscanProvider.prototype.handleRequests = function(self){
+  self._handleRequests(self)
+  if(self.requests.length == 0) {
+    unref(self.intervalId);
+  }
+}
+
+EtherscanProvider.prototype._handleRequests = function(self){
   if(self.requests.length == 0) return;
 
   //console.log('Handling the next ' + self.times + ' of ' + self.requests.length + ' requests');
@@ -70,6 +78,7 @@ EtherscanProvider.prototype.handleRequest = function(payload, next, end){
       };
 
   this.requests.push(requestObject);
+  ref(this.intervalId);
 }
 
 function handlePayload(apiKey, proto, network, payload, next, end){
@@ -243,3 +252,12 @@ function etherscanXHR(apiKey, useGetMethod, proto, network, module, action, para
     end(null, data.result)
   })
 }
+
+function unref (timeout) {
+  if (timeout.unref) timeout.unref();
+}
+
+function ref (timeout) {
+  if (timeout.ref) timeout.ref();
+}
+

--- a/subproviders/etherscan.js
+++ b/subproviders/etherscan.js
@@ -206,6 +206,10 @@ function etherscanXHR(apiKey, useGetMethod, proto, network, module, action, para
 
     if (err) return end(err)
 
+    if (res.statusCode > 300) {
+      return end(res.statusMessage || body)
+    }
+
     /*console.log('[etherscan request]'
           + ' method: ' + useGetMethod
           + ' proto: ' + proto
@@ -214,10 +218,7 @@ function etherscanXHR(apiKey, useGetMethod, proto, network, module, action, para
           + ' action: ' + action
           + ' params: ' + params
           + ' return body: ' + body);*/
-  
-    if(body.indexOf('403 - Forbidden: Access is denied.') > -1)
-      return end('403 - Forbidden: Access is denied.')
-    
+
     var data
     try {
       data = JSON.parse(body)

--- a/subproviders/etherscan.js
+++ b/subproviders/etherscan.js
@@ -38,35 +38,35 @@ function EtherscanProvider(opts) {
   this.times = isNaN(opts.times) ? 4 : opts.times;
   this.interval = isNaN(opts.interval) ? 1000 : opts.interval;
   this.retryFailed = typeof opts.retryFailed === 'boolean' ? opts.retryFailed : true; // not built yet
-  
+
   setInterval(this.handleRequests, this.interval, this);
 }
 
 EtherscanProvider.prototype.handleRequests = function(self){
-	if(self.requests.length == 0) return;
-	
-	//console.log('Handling the next ' + self.times + ' of ' + self.requests.length + ' requests');
-	
-	for(var requestIndex = 0; requestIndex < self.times; requestIndex++) {
-		var requestItem = self.requests.shift()
-  		
-		if(typeof requestItem !== 'undefined')
-			handlePayload(requestItem.proto, requestItem.network, requestItem.payload, requestItem.next, requestItem.end)
-	}
+  if(self.requests.length == 0) return;
+
+  //console.log('Handling the next ' + self.times + ' of ' + self.requests.length + ' requests');
+
+  for(var requestIndex = 0; requestIndex < self.times; requestIndex++) {
+    var requestItem = self.requests.shift()
+
+    if(typeof requestItem !== 'undefined')
+      handlePayload(requestItem.proto, requestItem.network, requestItem.payload, requestItem.next, requestItem.end)
+  }
 }
 
 EtherscanProvider.prototype.handleRequest = function(payload, next, end){
   var requestObject = {proto: this.proto, network: this.network, payload: payload, next: next, end: end},
-	  self = this;
-  
+    self = this;
+
   if(this.retryFailed)
-	  requestObject.end = function(err, result){
-		  if(err === '403 - Forbidden: Access is denied.')
-			 self.requests.push(requestObject);
-		  else
-			 end(err, result);
-		  };
-	
+    requestObject.end = function(err, result){
+      if(err === '403 - Forbidden: Access is denied.')
+       self.requests.push(requestObject);
+      else
+       end(err, result);
+      };
+
   this.requests.push(requestObject);
 }
 
@@ -142,7 +142,7 @@ function handlePayload(proto, network, payload, next, end){
           tag: payloadObject.toBlock,
           boolean: payload.params[1] }, function(err, blockResult) {
             if(err) return end(err);
-
+  
             for(var transaction in blockResult.transactions){
               etherscanXHR(true, proto, network, 'proxy', 'eth_getTransactionReceipt', { txhash: transaction.hash }, function(err, receiptResult) {
                 if(!err) logs.concat(receiptResult.logs);
@@ -189,7 +189,7 @@ function toQueryString(params) {
 
 function etherscanXHR(useGetMethod, proto, network, module, action, params, end) {
   var uri = proto + '://' + network + '.etherscan.io/api?' + toQueryString({ module: module, action: action }) + '&' + toQueryString(params)
-	
+  
   xhr({
     uri: uri,
     method: useGetMethod ? 'GET' : 'POST',
@@ -202,19 +202,19 @@ function etherscanXHR(useGetMethod, proto, network, module, action, params, end)
     // console.log('[etherscan] response: ', err)
 
     if (err) return end(err)
-	
-	  /*console.log('[etherscan request]' 
-				  + ' method: ' + useGetMethod
-				  + ' proto: ' + proto
-				  + ' network: ' + network
-				  + ' module: ' + module
-				  + ' action: ' + action
-				  + ' params: ' + params
-				  + ' return body: ' + body);*/
-	
+
+    /*console.log('[etherscan request]'
+          + ' method: ' + useGetMethod
+          + ' proto: ' + proto
+          + ' network: ' + network
+          + ' module: ' + module
+          + ' action: ' + action
+          + ' params: ' + params
+          + ' return body: ' + body);*/
+  
     if(body.indexOf('403 - Forbidden: Access is denied.') > -1)
-    	return end('403 - Forbidden: Access is denied.')
-	  
+      return end('403 - Forbidden: Access is denied.')
+    
     var data
     try {
       data = JSON.parse(body)

--- a/subproviders/etherscan.js
+++ b/subproviders/etherscan.js
@@ -83,9 +83,19 @@ EtherscanProvider.prototype.handleRequest = function(payload, next, end){
 }
 
 function handlePayload(apiKey, proto, network, payload, next, end){
+  const params0 = payload.params[0]
   switch(payload.method) {
     case 'eth_blockNumber':
       etherscanXHR(apiKey, true, proto, network, 'proxy', 'eth_blockNumber', {}, end)
+      return
+
+    case 'eth_estimateGas':
+      etherscanXHR(apiKey, true, proto, network, 'proxy', 'eth_estimateGas', pickNonNull({
+        to: params0.to,
+        value: params0.value,
+        gasPrice: params0.gasPrice,
+        gas: params0.gas
+      }), end)
       return
 
     case 'eth_getBlockByNumber':
@@ -263,6 +273,17 @@ function unref (timeout) {
 
 function ref (timeout) {
   if (timeout.ref) timeout.ref();
+}
+
+function pickNonNull (obj) {
+  const defined = {}
+  for (let key in obj) {
+    if (obj[key] != null) {
+      defined[key] = obj[key]
+    }
+  }
+
+  return defined
 }
 
 function normalizeError (err) {


### PR DESCRIPTION
This PR combines a bunch of improvements we had to do for etherscan to work better.

- 34a07f062c956218c0f42b20a32b43a44884e7bd - feat: adding support for api-keys
     Etherscan requires API-keys to be used for a while now. With this commit adds a `apiKey` property to etherscan provider.
- 75c4185fc4fe8715c055d86a8f146cac8726e4fe - feat: allowing to specify networks using common network specifiers
    The networks, specified in other parts of the code, use things like `mainnet`, `goerli` etc. as specifier. these are available at etherscan through a `api-<network>` subdomains. This commit should make it easier to specify the network correctly.
- 9e09aa00b8f920d06b9b02a7b0b999bf25f4cddb - fix: allowing any kind of statusCode
    Before this commit only 403 error were handled by the subprovider. With this commit any unexpected status code is treated by errors.
- 69615bdb26e8096a387f3abc7ac1c9a820d7e259 - fix: returning the error itself if the message isn't given.
    There is a chance that errors are returned without message, in this case the callback is returned with null, indicating no error occurred. With this commit it is made sure that an error is always returned.
- d5650e287ddf1cff36b4ee9fc57fc7057a9ec029 - fix: de-referencing interval if no request is pending.
    Before this commit an interval was running by merely instantiating Etherscan. Now it runs only if there is actually work that may be done.
- e8d91c7eec51b6bbf5fb59c337239ae6c8c510f3 - fix: only use defined properties during transaction listening.
    We use configuration properties to fill the requests to etherscan. This commit allows to specify one as "undefined" and not break the request.
- cb61e5b6bf4d5acfc971bfb1580a2e1dd19d85c5 - fix: making sure that callbacks are always called with error instances
    Callback API's usually return error instances in the first argument. With this commit every response is guaranteed to be an error instance
- 40105e816292b7acf467ebce5795fe1ebd84253f - feat: adding support for gas estimate through etherscan
    Etherscan has a convenient API to calculate the gas required for an operation. With this commit it can be used.