### PR TITLE
chore: remove unused cross-fetch dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "async": "^2.5.0",
     "backoff": "^2.5.0",
     "clone": "^2.0.0",
-    "cross-fetch": "^2.1.0",
     "eth-block-tracker": "^4.4.2",
     "eth-json-rpc-filters": "^4.2.1",
     "eth-json-rpc-infura": "^5.1.0",


### PR DESCRIPTION
There is no reference to cross-fetch in the repository. This PR removes this unused dependency.