### PR TITLE
fix: allow to set a defaultGas in case no transactions are in the blocks

### DIFF
--- a/subproviders/gasprice.js
+++ b/subproviders/gasprice.js
@@ -19,6 +19,7 @@ function GaspriceProvider(opts) {
   opts = opts || {}
   this.numberOfBlocks = opts.numberOfBlocks || 10
   this.delayInBlocks = opts.delayInBlocks || 5
+  this.defaultGas = opts.defaultGas || 1
 }
 
 GaspriceProvider.prototype.handleRequest = function(payload, next, end){
@@ -48,6 +49,15 @@ GaspriceProvider.prototype.handleRequest = function(payload, next, end){
     function calcPrice(err, transactions) {
       // flatten array
       transactions = transactions.reduce(function(a, b) { return a.concat(b) }, [])
+
+      if (transactions.length === 0) {
+        if (self.defaultGas > 0) {
+          end(null, self.defaultGas)
+        } else {
+          end(new Error('No transactions found to base the gas-price of.'))
+        }
+        return
+      }
 
       // leave only the gasprice
       // FIXME: convert number using a bignum library


### PR DESCRIPTION
Estimating the gas requires a transaction in the last ten blocks. This is problematic when running against a test-node that has just been set up and contains no transactions. For this cases this PR adds a `.defaultGas` option that is used with no Transactions given. Setting `.defaultGas` to `0` or `null` will let it throw an error.