### PR TITLE
16.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [16.0.4] - 2022-04-29
+
+### Fixed
+
+- Remove vulnerable version of `cross-fetch` ([#404](https://github.com/MetaMask/web3-provider-engine/pull/404))
+
 ## [16.0.3] - 2021-07-15
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web3-provider-engine",
-  "version": "16.0.3",
+  "version": "16.0.4",
   "description": "A JavaScript library for composing Ethereum provider objects using middleware modules",
   "repository": "https://github.com/MetaMask/web3-provider-engine",
   "main": "index.js",


### PR DESCRIPTION
### Fixed

- Remove vulnerable version of `cross-fetch` ([#404](https://github.com/MetaMask/web3-provider-engine/pull/404))