### PR TITLE
chore: add the setTimeout timer for avoiding some edge cases.

### DIFF
--- a/util/stoplight.js
+++ b/util/stoplight.js
@@ -29,6 +29,6 @@ Stoplight.prototype.await = function(fn){
   if (self.isLocked) {
     self.once('unlock', fn)
   } else {
-    setTimeout(fn)
+    setTimeout(fn, 0)
   }
 }


### PR DESCRIPTION
In some building or runtime, this potential issue could throw a error.
```
setTimeout(fn) => setTimeout(fn, 0)
```