### PR TITLE
Support users using yarn berry but use classic mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+# Yarn 3
+.yarn/cache
+.yarn/install-state.gz

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,3 @@
+nodeLinker: node-modules
+
+yarnPath: .yarn/releases/yarn-1.22.19.cjs

--- a/package.json
+++ b/package.json
@@ -63,5 +63,6 @@
   "browser": {
     "request": false,
     "ws": false
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
If you happen to be using yarn berry as your yarn executable it can cause issues when working with repos that were set up with yarn classic. However, you can set your executable of yarn to classic so that whether you're using yarn 1 or yarn2+ that it'll work the same. This change should have no impact on the library but allow those of us using yarn berry to operate without swiching our executable. 